### PR TITLE
add overload method writeCSV to support customerize file format

### DIFF
--- a/excel/pom.xml
+++ b/excel/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cn.com.binging</groupId>
     <artifactId>excel</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
 
     <name>bing-excel</name>
@@ -237,14 +237,4 @@
             <url>file:///D:/maven/excelreps/mvn-repo/repository</url>
         </repository>
     </distributionManagement>-->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>bc_tuxedo_snapshots</id>
-            <url>http://10.147.20.2:8081/repository/bc_tuxedo_snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>bc_tuxedo_releases</id>
-            <url>http://10.147.20.2:8081/repository/bc_tuxedo_releases/</url>
-        </repository>
-    </distributionManagement>
 </project>

--- a/excel/pom.xml
+++ b/excel/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cn.com.binging</groupId>
     <artifactId>excel</artifactId>
-    <version>2.2.1</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>bing-excel</name>
@@ -237,4 +237,14 @@
             <url>file:///D:/maven/excelreps/mvn-repo/repository</url>
         </repository>
     </distributionManagement>-->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>bc_tuxedo_snapshots</id>
+            <url>http://10.147.20.2:8081/repository/bc_tuxedo_snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>bc_tuxedo_releases</id>
+            <url>http://10.147.20.2:8081/repository/bc_tuxedo_releases/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/excel/src/main/java/com/bing/excel/core/BingExcel.java
+++ b/excel/src/main/java/com/bing/excel/core/BingExcel.java
@@ -17,112 +17,104 @@ import com.bing.excel.core.impl.BingExcelImpl;
 
 
 /**
- * 操作excel的类，需要poi3.13的jar包<br>
- * maven地址,目前仅支持03版本
- * <p>
- * &ltdependency&gt<br>
- * &nbsp;&ltgroupId&gtorg.apache.poi&lt/groupId&gt<br>
- * &nbsp;&ltartifactId&gtpoi&lt/artifactId&gt<br>
- * &nbsp; &ltversion&gt3.8&lt/version&gt<br>
- * &lt/dependency&gt
- * </p>
- * 
+ * 操作excel的类，需要poi3.13的jar包<br> maven地址,目前仅支持03版本 <p> &ltdependency&gt<br>
+ * &nbsp;&ltgroupId&gtorg.apache.poi&lt/groupId&gt<br> &nbsp;&ltartifactId&gtpoi&lt/artifactId&gt<br>
+ * &nbsp; &ltversion&gt3.8&lt/version&gt<br> &lt/dependency&gt </p>
+ *
  * @author shizhongtao
- * 
- *         2015 2015-4-24 下午5:49:55
- * 
+ *
+ * 2015 2015-4-24 下午5:49:55
  */
 public interface BingExcel {
-	/**
-	 * <p>
-	 * Title: readFileToList<／p>
-	 * <p>
-	 * Description:读取excel 的第一个sheet页到list<／p>
-	 * 
-	 * @param file excel对应的文件
-	 * @param clazz 要转换类型的class对象
-	 * @param startRowNum 从第几行开始读取
-	 * @return 
-	 * @throws Exception 
-	 */
-	<T> BingExcelImpl.SheetVo<T> readFile(File file, Class<T> clazz, int startRowNum) throws Exception ;
-	/**
-	 * 根据condition条件读取相应的sheet到list对象
-	 * @param file
-	 * @param condition
-	 * @return
-	 * @throws Exception 
-	 */
-	<T> BingExcelImpl.SheetVo<T> readFile(File file, ReaderCondition<T> condition) throws Exception ;
 
-	
-	 /**
-	  * 读取所condition 对应 sheet表格，到list
-	 * @param file
-	 * @param conditions 每个表格对应的condition，注：对于返回的条数，取conditions中 endNum的最小值
-	 * @return sheetVo的list对象，如果没有符合conditions的结果，返回empetyList对象
-	 * @throws Exception 
-	 */
-	List<BingExcelImpl.SheetVo> readFileToList(File file, ReaderCondition[] conditions) throws Exception ;
-	 
-	 
-	<T> BingExcelImpl.SheetVo<T> readStream(InputStream stream, ReaderCondition<T> condition) throws InvalidFormatException, IOException, SQLException, OpenXML4JException, SAXException ;
+    /**
+     * <p> Title: readFileToList<／p> <p> Description:读取excel 的第一个sheet页到list<／p>
+     *
+     * @param file excel对应的文件
+     * @param clazz 要转换类型的class对象
+     * @param startRowNum 从第几行开始读取
+     */
+    <T> BingExcelImpl.SheetVo<T> readFile(File file, Class<T> clazz, int startRowNum)
+            throws Exception;
 
-	/**
-	 * read sheet witch index equal 0
-	 * @param stream
-	 * @return
-	 * @throws SQLException 
-	 * @throws IOException 
-	 * @throws InvalidFormatException 
-	 * @throws SAXException 
-	 */
-	<T> BingExcelImpl.SheetVo<T> readStream(InputStream stream, Class<T> clazz, int startRowNum) throws InvalidFormatException, IOException, SQLException ,OpenXML4JException, SAXException;
+    /**
+     * 根据condition条件读取相应的sheet到list对象
+     */
+    <T> BingExcelImpl.SheetVo<T> readFile(File file, ReaderCondition<T> condition) throws Exception;
 
-	 /**
-	  * read sheets 
-	 * @param stream
-	 * @param condition
-	 * @return
-	 * @throws InvalidFormatException
-	 * @throws IOException
-	 * @throws SQLException
-	 * @throws OpenXML4JException
-	 * @throws SAXException
-	 */
-	List<BingExcelImpl.SheetVo> readStreamToList(InputStream stream, ReaderCondition[] condition) throws InvalidFormatException, IOException, SQLException, OpenXML4JException, SAXException ;
-	
-	/**
-	 * 输出model集合到excel 文件。
-	 * @param iterables 要输出到文件的集合对象，
-	 * @param file 文件对象
-	 */
-	 void writeExcel(File file,Iterable... iterables)throws FileNotFoundException;
-	 void writeOldExcel(File file,Iterable... iterables)throws FileNotFoundException;
-	/**
-	 * 输出model集合到excel 文件。
-	 * @param iterables
-	 * @param path 文件路径
-	 */
-	 void writeExcel(String path,Iterable... iterables);
-/**
- * 写出xls格式的excel文件
-* @param path
-* @param iterables
-*/
-	 void writeOldExcel(String path,Iterable... iterables);
-	 /**
-	  * 写出xls格式的excel到输出流
-	 * @param stream
-	 * @param iterables
-	 */
-	void writeExcel(OutputStream stream,Iterable... iterables);
-	 void writeOldExcel(OutputStream stream,Iterable... iterables);
-	void writeCSV(String path,Iterable iterable) throws IOException;
-	void writeCSV(OutputStream os,Iterable iterable) throws IOException;
 
-  void modelName(Class<?> clazz, String alias);
+    /**
+     * 读取所condition 对应 sheet表格，到list
+     *
+     * @param conditions 每个表格对应的condition，注：对于返回的条数，取conditions中 endNum的最小值
+     * @return sheetVo的list对象，如果没有符合conditions的结果，返回empetyList对象
+     */
+    List<BingExcelImpl.SheetVo> readFileToList(File file, ReaderCondition[] conditions)
+            throws Exception;
 
-	void fieldConverter(Class<?> clazz, String filedName, int index, String alias,
-			FieldValueConverter converter);
+
+    <T> BingExcelImpl.SheetVo<T> readStream(InputStream stream, ReaderCondition<T> condition)
+            throws InvalidFormatException, IOException, SQLException, OpenXML4JException, SAXException;
+
+    /**
+     * read sheet witch index equal 0
+     */
+    <T> BingExcelImpl.SheetVo<T> readStream(InputStream stream, Class<T> clazz, int startRowNum)
+            throws InvalidFormatException, IOException, SQLException, OpenXML4JException, SAXException;
+
+    /**
+     * read sheets
+     */
+    List<BingExcelImpl.SheetVo> readStreamToList(InputStream stream, ReaderCondition[] condition)
+            throws InvalidFormatException, IOException, SQLException, OpenXML4JException, SAXException;
+
+    /**
+     * 输出model集合到excel 文件。
+     *
+     * @param iterables 要输出到文件的集合对象，
+     * @param file 文件对象
+     */
+    void writeExcel(File file, Iterable... iterables) throws FileNotFoundException;
+
+    void writeOldExcel(File file, Iterable... iterables) throws FileNotFoundException;
+
+    /**
+     * 输出model集合到excel 文件。
+     *
+     * @param path 文件路径
+     */
+    void writeExcel(String path, Iterable... iterables);
+
+    /**
+     * 写出xls格式的excel文件
+     */
+    void writeOldExcel(String path, Iterable... iterables);
+
+    /**
+     * 写出xls格式的excel到输出流
+     */
+    void writeExcel(OutputStream stream, Iterable... iterables);
+
+    void writeOldExcel(OutputStream stream, Iterable... iterables);
+
+    void writeCSV(String path, Iterable iterable) throws IOException;
+
+    void writeCSV(OutputStream os, Iterable iterable) throws IOException;
+
+    /**
+     * 写出指定分隔符、指定是否写header的文件到输出流
+     *
+     * @param os 输出流
+     * @param iterable 带转换的对象
+     * @param delimiter 分隔符
+     * @param isWithHeader 是否写入header行
+     * @param isWithBOM 是否带BOM
+     */
+    void writeCSV(OutputStream os, Iterable iterable, char delimiter, boolean isWithHeader, boolean isWithBOM)
+            throws IOException;
+
+    void modelName(Class<?> clazz, String alias);
+
+    void fieldConverter(Class<?> clazz, String filedName, int index, String alias,
+            FieldValueConverter converter);
 }

--- a/excel/src/test/java/com/chinamobile/excel/WriteTest6.java
+++ b/excel/src/test/java/com/chinamobile/excel/WriteTest6.java
@@ -1,6 +1,5 @@
 package com.chinamobile.excel;
 
-import com.bing.excel.annotation.BingConvertor;
 import com.bing.excel.annotation.CellConfig;
 import com.bing.excel.annotation.OutAlias;
 import com.bing.excel.converter.AbstractFieldConvertor;
@@ -11,6 +10,9 @@ import com.bing.excel.vo.OutValue;
 import com.bing.excel.vo.OutValue.OutType;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
@@ -44,6 +46,94 @@ public class WriteTest6 {
 
 
   }
+
+  @Test
+  public void csvWrite_semiColon_noHead() throws IOException {
+    BingExcel bingExcel = BingExcelBuilder.toBuilder().build();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    List<ApiUsedNumForCSV>  list= Lists.newArrayList();
+    ApiUsedNumForCSV api1 = new ApiUsedNumForCSV();
+    api1.setDate("2018-10");
+    api1.setOwnerId("5632643255427352877312350");
+    api1.setTopicName("test1");
+    api1.setUsedNum(100000L);
+    ApiUsedNumForCSV api2 = new ApiUsedNumForCSV();
+    api2.setDate("2018-10");
+    api2.setOwnerId("5632643255427352877312350");
+    api2.setTopicName("test2");
+    api2.setUsedNum(200000L);
+    ApiUsedNumForCSV api3 = new ApiUsedNumForCSV();
+    api3.setDate("2018-10");
+    api3.setOwnerId("5632643255427352877312350");
+    api3.setTopicName("test3");
+    api3.setUsedNum(300000L);
+    list.add(api1);
+    list.add(api2);
+    list.add(api3);
+
+    bingExcel.writeCSV(os, list, ';', false, false);
+    String result = new String(os.toByteArray());
+    System.out.println(result);
+
+    File file = new File("E:\\test.csv");
+    FileOutputStream fileOutputStream = new FileOutputStream(file);
+    fileOutputStream.write(os.toByteArray());
+    fileOutputStream.close();
+  }
+
+  /**
+   * Model类。生成CSV文件用。表示每月的api调用次数计量信息。
+   *
+   * @author chengxiangwang
+   * @create 2018/10/30
+   */
+  static class ApiUsedNumForCSV{
+    //Format: 2018-10
+    @CellConfig(index = 0)
+    private String month;
+    @CellConfig(index = 1)
+    private String topicName;
+    @CellConfig(index = 2)
+    private String ownerId;
+    @CellConfig(index = 3)
+    private Long apiUsedNum;
+
+    public ApiUsedNumForCSV() {
+
+    }
+    public String getTopicName() {
+      return topicName;
+    }
+
+    public void setTopicName(String topicName) {
+      this.topicName = topicName;
+    }
+
+    public String getOwnerId() {
+      return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+      this.ownerId = ownerId;
+    }
+
+    public String getDate() {
+      return month;
+    }
+
+    public void setDate(String month) {
+      this.month = month;
+    }
+
+    public Long getUsedNum() {
+      return apiUsedNum;
+    }
+
+    public void setUsedNum(Long apiUsedNum) {
+      this.apiUsedNum = apiUsedNum;
+    }
+  }
+
 
   @OutAlias("xiaoshou1")
   public static class Person {


### PR DESCRIPTION
add overload method writeCSV below:
    /**
     * 写出指定分隔符、指定是否写header的文件到输出流
     *
     * @param os 输出流
     * @param iterable 带转换的对象
     * @param delimiter 分隔符
     * @param isWithHeader 是否写入header行
     * @param isWithBOM 是否带BOM
     */
    void writeCSV(OutputStream os, Iterable iterable, char delimiter, boolean isWithHeader, boolean isWithBOM)
            throws IOException;

It can:
1. use the customized delimiter
2. specify whether with BOM or not
3. specify whether with header or not